### PR TITLE
Picolibc support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ endif
 VERBOSE=n
 OPT=g
 USE_NANO=y
+USE_PICO=n
 SEMIHOST=n
 USE_FPU=y
 # Libraries
@@ -89,11 +90,21 @@ LDFLAGS+=-nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET_MAP) -Wl,--cref
 
 ifeq ($(USE_NANO),y)
 LDFLAGS+=--specs=nano.specs
+# Force newlib instread of nano
+USE_PICO:=n
 endif
 
 ifeq ($(SEMIHOST),y)
 DEFINES+=USE_SEMIHOST
 LDFLAGS+=--specs=rdimon.specs
+# Force newlib instread of nano
+USE_PICO:=n
+endif
+
+ifeq ($(USE_PICO),y)
+DEFINES+=USE_PICOLIBC
+COMMON_FLAGS+=-specs=picolibc.specs
+LDFLAGS+=-specs=picolibc.specs
 endif
 
 CROSS=arm-none-eabi-

--- a/libs/sapi/sapi_v0.5.2/abstract_modules/src/sapi_stdio.c
+++ b/libs/sapi/sapi_v0.5.2/abstract_modules/src/sapi_stdio.c
@@ -62,8 +62,6 @@
 #include "sapi_stdio.h"
 
 /*==================[macros and definitions]=================================*/
-
-#define putchar(c)      outbyte(c)
 #define PAD_RIGHT       1
 #define PAD_ZERO        2
 #define PRINT_BUF_LEN   12
@@ -110,12 +108,11 @@ void outbyte(int c)
  */
 static void printchar(char **str, int c)
 {
-   extern void putchar(int c);
    if (str) {
       **str = c;
       ++(*str);
    } else {
-      (void)putchar(c);
+      (void)outbyte(c);
    }
 }
 

--- a/libs/sys_newlib/src/system.c
+++ b/libs/sys_newlib/src/system.c
@@ -12,6 +12,7 @@
 
 WEAK void __stdio_putchar(int c);
 WEAK int __stdio_getchar();
+WEAK void __stdio_yield();
 WEAK_INIT void __stdio_init();
 
 void __stdio_init() {
@@ -23,6 +24,9 @@ void __stdio_putchar(int c) {
 
 int __stdio_getchar() {
    return -1;
+}
+
+void __stdio_yield() {
 }
 
 void _exit(int code) {
@@ -266,7 +270,18 @@ static int ao_putc(char c, FILE *ignore) {
 
 static int ao_getc(FILE *ignore) {
    UNUSED(ignore);
-   return __stdio_getchar();
+   int c;
+   while ((c = __stdio_getchar()) == -1) {
+         __stdio_yield();
+   }
+   __stdio_putchar(c);
+   switch (c) {
+   case '\r':
+   case '\n':
+      return -1;
+   default:
+      return c;
+   }
 }
 
 static FILE __stdio = {

--- a/libs/sys_newlib/src/system.c
+++ b/libs/sys_newlib/src/system.c
@@ -250,3 +250,32 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr) {
    heap_end += incr;
    return prev_heap_end;
 }
+
+#ifdef USE_PICOLIBC
+#include <stdio.h>
+
+static int ao_flush(FILE *ignore) {
+   UNUSED(ignore);
+   return 0;
+}
+
+static int ao_putc(char c, FILE *ignore) {
+   __stdio_putchar(c);
+   return 0;
+}
+
+static int ao_getc(FILE *ignore) {
+   UNUSED(ignore);
+   return __stdio_getchar();
+}
+
+static FILE __stdio = {
+   .flags = __SRD|__SWR,
+   .put = ao_putc,
+   .get = ao_getc,
+   .flush = ao_flush,
+};
+
+FILE *const __iob[3] = { &__stdio, &__stdio, &__stdio };
+
+#endif


### PR DESCRIPTION
This PR implements picolibc [0] support in firmware-v3.

PicoLibc is a revamp of newlib removing all gpl/lgpl code and merging avrlibc stdio infrastructure. Due this, the size of final binary shrink at least 60%