### PR TITLE
Fixes on DAC/ADC PID example

### DIFF
--- a/examples/c/sapi/control/pid_control_rtos/inc/pid_controller.h
+++ b/examples/c/sapi/control/pid_control_rtos/inc/pid_controller.h
@@ -61,7 +61,7 @@ extern "C" {
 
 /*=====[Definition macros of public constants]===============================*/
 
-#define PID_PRINT_RESULT
+// #define PID_PRINT_RESULT
 
 #ifdef PID_PRINT_RESULT
 // Number of samples to save

--- a/examples/c/sapi/control/pid_control_rtos/inc/pid_controller.h
+++ b/examples/c/sapi/control/pid_control_rtos/inc/pid_controller.h
@@ -4,7 +4,7 @@
  * All rights reserved.
  * License: BSD-3-Clause <https://opensource.org/licenses/BSD-3-Clause>)
  *
- * Version: 1.2.0
+ * Version: 1.3.0
  * Creation Date: 2018/09/24
  */
 
@@ -61,7 +61,7 @@ extern "C" {
 
 /*=====[Definition macros of public constants]===============================*/
 
-//#define PID_PRINT_RESULT
+#define PID_PRINT_RESULT
 
 #ifdef PID_PRINT_RESULT
 // Number of samples to save
@@ -69,6 +69,10 @@ extern "C" {
 #endif
 
 /*=====[Public function-like macros]=========================================*/
+
+// adcRead() returns 10 bits integer sample (uint16_t)
+// sampleInVolts = (3.3 / 1023.0) * adcSample
+#define getVoltsSampleFrom(adc0Channel) 3.3*(float)adcRead((adc0Channel))/1023.0
 
 /*=====[Definitions of public data types]====================================*/
 

--- a/examples/c/sapi/control/pid_control_rtos/src/pidTask.c
+++ b/examples/c/sapi/control/pid_control_rtos/src/pidTask.c
@@ -2,8 +2,15 @@
  * Copyright (c) 2019, Eric Pernia <ericpernia@gmail.com>
  * All rights reserved.
  * License: bsd-3-clause (see LICENSE.txt)
- * Date: 2019/09/16
- * Version: 1.0.0
+ * Date: 2019/10/8
+ * Version: 1.1.0
+ *
+ * Changelog:
+ * Version 1.1.0, 2019/10/8, Santiago Germino <sgermino@retro-ciaa.com>:
+ *    1) Name change for SCALE_OUT(Y), SCALE_REF(R), SCALE_PID_OUT(U).
+ *    2) Proper values for SCALE_Y, SCALE_R and SCALE_U.
+ *    3) Proper scaling of Ki and Kd by h_s.
+ *    4) Added calls to enable and initialize ADC & DAC.
  *===========================================================================*/
 
 /*=====[Inclusion of own header]=============================================*/
@@ -17,10 +24,10 @@
 
 /*=====[Definition macros of private constants]==============================*/
 
-#define SCALE_OUT       100.0f
-#define SCALE_REF       100.0f
-#define SCALE_PID_OUT   100.0f
-        
+#define SCALE_Y         0.003225806f    // 3.3 / 1023     10-bit ADC to Voltage
+#define SCALE_R         0.003225806f    // 3.3 / 1023     10-bit ADC to Voltage
+#define SCALE_U         310.0f          // 1023 / 3.3     Voltage to 10-bit DAC
+
 /*=====[Private function-like macros]========================================*/
 
 /*=====[Definitions of private data types]===================================*/
@@ -49,20 +56,25 @@ void pidControlTask( void* taskParmPtr )
    // h no puede ser menor ni al tiempo del algoritmo, y con va a ser un
    // multiplo del periodo de tick del RTOS
    uint32_t h_ms = 4; // Task periodicity (sample rate)
+   float h_s = ((float)h_ms)/1000.0f;
+
+   // Enable ADC/DAC
+   adcInit( ADC_ENABLE );
+   dacInit( DAC_ENABLE );
 
    // PID Controller structure (like an object instance)
    PIDController_t PsPIDController;
 
    // PID Controller Initialization
    pidInit( &PsPIDController,
-            2.8,                   // Kp
-            1.2,                   // Ki
-            0.1,                   // Kd
-            ((float)h_ms)/1000.0f, // h en [s]
+            2.8f,                  // Kp
+            1.2f / h_s,            // Ki
+            0.1f * h_s,            // Kd
+            h_s,                   // h en [s]
             20.0f,                 // N
             1.0f,                  // b
-            30.0f,                 // u_min
-            60.0f                  // u_max
+            0.0f,                  // u_min
+            3.3f                   // u_max
           );
 
    // Peridodic task each h_ms
@@ -83,14 +95,14 @@ void pidControlTask( void* taskParmPtr )
       #endif
 
       // Leer salida y[k] y refererencia r[k]
-      y = adcRead( CH1 ) * SCALE_OUT;
-      r = adcRead( CH2 ) * SCALE_REF;
+      y = adcRead( CH1 ) * SCALE_Y;
+      r = adcRead( CH2 ) * SCALE_R;
 
       // Calculate PID controller output u[k]
-      u = pidCalculateControllerOutput( &PsPIDController, y, r );
+      u = pidCalculateControllerOutput( &PsPIDController, y, r ) * SCALE_U;
 
       // Actualizar la salida u[k]
-      dacWrite( DAC, u * SCALE_PID_OUT );
+      dacWrite( DAC, u);
 
       // Update PID controller for next iteration
       pidUpdateController( &PsPIDController, y, r );

--- a/libs/lpc_fatfs_disks/source/fssdc.c
+++ b/libs/lpc_fatfs_disks/source/fssdc.c
@@ -35,7 +35,6 @@
 /*  ELM-Chan Says:
  
     On Initialization: Set SPI clock rate between 100 kHz and 400 kHz.
-    
     After: The SCLK rate should be changed to fast as possible to maximize the 
     read/write performance. The TRAN_SPEED field in the CSD register indicates 
     the maximum clock rate of the card. The maximum clock rate is 20MHz for MMC,
@@ -59,14 +58,14 @@
 #endif
 
 #ifndef FSSDC_SPI_FAST_CLOCK
-#define FSSDC_SPI_FAST_CLOCK            25000000
+#define FSSDC_SPI_FAST_CLOCK            15000000
 #endif
 
 
 /* Definitions for MMC/SDC command */
 #define CMD0_	(0x40+0)	 /* GO_IDLE_STATE */
-#define CMD1	(0x40+1)     /* SEND_OP_COND (MMC) */
-#define	ACMD41	(0xC0+41)    /* SEND_OP_COND (SDC) */
+#define CMD1	(0x40+1)	 /* SEND_OP_COND (MMC) */
+#define	ACMD41	(0xC0+41)	 /* SEND_OP_COND (SDC) */
 #define CMD8	(0x40+8)	 /* SEND_IF_COND */
 #define CMD9	(0x40+9)	 /* SEND_CSD */
 #define CMD10	(0x40+10)	 /* SEND_CID */
@@ -76,7 +75,7 @@
 #define CMD17	(0x40+17)	 /* READ_SINGLE_BLOCK */
 #define CMD18	(0x40+18)	 /* READ_MULTIPLE_BLOCK */
 #define CMD23	(0x40+23)	 /* SET_BLOCK_COUNT (MMC) */
-#define ACMD23  (0xC0+23)    /* SET_WR_BLK_ERASE_COUNT (SDC) */
+#define ACMD23	(0xC0+23)	 /* SET_WR_BLK_ERASE_COUNT (SDC) */
 #define CMD24	(0x40+24)	 /* WRITE_BLOCK */
 #define CMD25	(0x40+25)	 /* WRITE_MULTIPLE_BLOCK */
 #define CMD55	(0x40+55)	 /* APP_CMD */


### PR DESCRIPTION
Basicamente resolvi un par de bugs y errores de compilacion con PID_PRINT_RESULT y ahora es un ejemplo totalmente funcional de uso del controlador PID con ADC/DAC.

	pic_controller.c Changelog:
	Version 1.3.0, 2019/10/8, Santiago Germino <sgermino@retro-ciaa.com>:
	   1) pidCalculateControllerOutput(): u_sat updated only on saturation.
	   2) pidUpdateController(): saturation now detected by u != u_sat.
	   3) usat_array[]: new storage for real saturated values.
	   4) pidGatherDebugSamples(): debug code moved inside of their own function.
	   5) Use of floatToString() in 4).
	   6) getVoltsSampleFrom() macro moved to pid_controller.h.

	pidTask.c Changelog:
	Version 1.1.0, 2019/10/8, Santiago Germino <sgermino@retro-ciaa.com>:
	   1) Name change for SCALE_OUT(Y), SCALE_REF(R), SCALE_PID_OUT(U).
	   2) Proper values for SCALE_Y, SCALE_R and SCALE_U.
	   3) Proper scaling of Ki and Kd by h_s.
	   4) Added calls to enable and initialize ADC & DAC.

