### PR TITLE
Fix openocd script for new versions (0.10+).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ OOCD_SCRIPT=scripts/openocd/lpc4337.cfg
 	$(Q)$(OOCD) -f $(OOCD_SCRIPT) \
 		-c "init" \
 		-c "halt 0" \
-		-c "flash write_image erase unlock $< 0x1A000000 bin" \
+		-c "flash write_image erase $< 0x1A000000 bin" \
 		-c "reset run" \
 		-c "shutdown" 2>&1
 

--- a/scripts/openocd/lpc4337.cfg
+++ b/scripts/openocd/lpc4337.cfg
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright 2014, Juan Cecconi (UTN-FRBA, Numetron)
+# Copyright 2019, Martin Ribelotta
 #
 # This file is part of CIAA Firmware.
 #
@@ -31,136 +31,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ###############################################################################
-#OpenOCD configuration (target and interface) for CIAA-NXP
 
-######################################################################################################
-# Utilizar una interface tipo FTDI, todo lo que sigue está basado en ello
-######################################################################################################
-interface ftdi
-
-######################################################################################################
-# Agrego el Par VID-PID del FTDI, si hay más agregar a continuación...
-######################################################################################################
-ftdi_vid_pid 0x0403 0x6010
-
-######################################################################################################
-# Se utilizó el Channel A (ADBUS0 a ADBUS3) para conectar el JTAG mediante MPSSE
-######################################################################################################
-ftdi_channel 0
-
-######################################################################################################
-# ftdi_layout_init 'Valor' 'Dirección', Configura los GPIO (H-L), su valor y dirección en ese orden(1 = Salida, 0 = entrada)
-# los 16 bits se arman H-L como sigue 'ACBUS7-0+ADBUS7-0'
-#ADBUS0 = FT_CLCK = 1, salida de Clock
-#ADBUS1 = FT_TDI = 1, salida de datos del FT
-#ADBUS2 = FT_TDO = 0, entrada de datos al FT
-#ADBUS3 = FT_TMS = 1, salida de Test Mode Select, setear a 1
-#ADBUS4 = Pin 14 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ADBUS5 = Pin 12 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ADBUS6 = Pin 10 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ADBUS7 = Pin 8 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ACBUS0 = FT_TRST = 1, salida de TRST...va al buffer y luego no se usa, setear a 1
-#ACBUS1 = FT_RST = 1, salida de RST...va al buffer y luego no se usa, setear a 1
-#ACBUS2 = FT_OE = 1, salida de OE para manejar el Buffer del JTAG, setear a 1
-#ACBUS3 = Pin 6 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ACBUS4 = Pin 4 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ACBUS5 = Pin 2 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ACBUS6 = Pin 1 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-#ACBUS7 = Pin 3 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
-######################################################################################################
-ftdi_layout_init 0x0708 0xFFFB
-
-######################################################################################################
-# La creación de las señales que siguen no hacen falta porque se indicó en el Target cfg que no se
-# las tiene conectadas a ningún lado
-######################################################################################################
-
-######################################################################################################
-# Creo la señal llamada nTRST (Not TAP Reset) que es una tipo dato, y usa el bit 8 del GPIO (H-L), es
-# decir GPIOH0 (pin ACBUS0) por eso 0x100, y a la vez se activa conjuntamente con el OE que
-# está usado en el bit 10 del GPIO, es decir, en GPIOH2 (pin ACBUS2) por eso 0x400
-######################################################################################################
-ftdi_layout_signal nTRST -data 0x0100
-
-######################################################################################################
-# Creo la señal llamada nSRST (Not System Reset) que se activa cuando se hace un cmd 'reset'
-# Es tipo dato y usa el bit 9 del GPIO (H-L), es decir GPIOH1 (pin ACBUS1) por eso 0x200,
-# y a la vez se activa conjuntamente con el OE que  está usado en el bit 10 del GPIO, es decir,
-# en GPIOH2 (pin ACBUS2) por eso 0x400
-######################################################################################################
-ftdi_layout_signal nSRST -data 0x0200
-
-################################################################
-# Especifica en KHz la frecuencia del Clock en el JTAG (TCK)
-################################################################
-transport select jtag
-adapter_khz 2000
-
-################################################################
-# Defino nombre de CHIP
-################################################################
-set _CHIPNAME lpc4337
-
-################################################################
-# Defino los TAP del JTAG, para el core M4 y M0
-################################################################
-
-# M4 JTAG mode TAP
-set _M4_JTAG_TAPID 0x4ba00477
-
-# M0 TAP
-set _M0_JTAG_TAPID 0x0ba01477
-
-jtag newtap $_CHIPNAME m4 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_M4_JTAG_TAPID
-
-jtag newtap $_CHIPNAME m0 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_M0_JTAG_TAPID
-
-################################################################
-# Creo los 2 targets lpc4337.m4 y lpc4337.m0
-################################################################
-target create $_CHIPNAME.m4 cortex_m -chain-position $_CHIPNAME.m4
-target create $_CHIPNAME.m0 cortex_m -chain-position $_CHIPNAME.m0
-
-################################################################
-# Defino un area de trabajo en la RAM para acelerar el proceso
-# de programación de la flash
-################################################################
-set _WORKAREASIZE 0x8000
-$_CHIPNAME.m4 configure -work-area-phys 0x10000000 -work-area-size $_WORKAREASIZE
-
-################################################################
-# Se define un banco de flash, grabable usando el driver lpc2000
-# que es compatible con el LPC4337
-# flash bank <name> lpc2000 <base> <size> 0 0 <target#> <variant> <clock> [calc checksum]
-################################################################
-set _FLASHNAME $_CHIPNAME.flash
-flash bank $_FLASHNAME lpc2000 0x1a000000 0x80000 0 0 $_CHIPNAME.m4 lpc4300 96000 calc_checksum
-
-################################################################
-# TRST (TAP Reset) y SRST (System Reset) no están conectados más allá del Buffer
-# en el prototipo.
-# Por lo tanto se indica 'none'
-################################################################
-reset_config none
-#reset_config trst_only
-
-################################################################
-# on this CPU we should use VECTRESET to perform a soft reset and
-# manually reset the periphery
-# SRST or SYSRESETREQ disable the debug interface for the time of
-# the reset and will not fit our requirements for a consistent debug
-# session
-################################################################
-cortex_m reset_config vectreset
-
-targets $_CHIPNAME.m4
-
-$_CHIPNAME.m4 configure -event gdb-attach {
-   echo "Reset Halt, due to gdb attached...!"
-   reset halt
-}
-
-$_CHIPNAME.m4 configure -event gdb-detach {
-   echo "Terminate openocd"
-   shutdown 0
+if { [info procs dap] eq "" } {
+   puts "dap command not exists. Use OLD script"
+   source scripts/openocd/lpc4337_old.cfg
+}  else {
+   puts "dap command not exists. Use NEW script"
+   source scripts/openocd/lpc4337_new.cfg
 }

--- a/scripts/openocd/lpc4337_new.cfg
+++ b/scripts/openocd/lpc4337_new.cfg
@@ -1,56 +1,72 @@
+###############################################################################
+#
+# Copyright 2019, Martin Ribelotta
+# 
+# Based on script writed by Juan Cecconi (UTN-FRBA, Numetron) in 2014
+#
+# This file is part of CIAA Firmware.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+###############################################################################
+
 interface ftdi
-ftdi_device_desc "Dual RS232-HS"
 ftdi_vid_pid 0x0403 0x6010
 ftdi_channel 0
-
 ftdi_layout_init 0x0708 0xFFFB
 ftdi_layout_signal nTRST -data 0x0100
 ftdi_layout_signal nSRST -data 0x0200
-
 transport select jtag
 adapter_khz 2000
 
-set _CHIPNAME lpc4337
+jtag newtap lpc4337 m4 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id 0x4ba00477
+dap create lpc4337.m4.dap -chain-position lpc4337.m4
+target create lpc4337.m4 cortex_m -dap lpc4337.m4.dap
 
-set _M4_JTAG_TAPID 0x4ba00477
-set _M0_JTAG_TAPID 0x0ba01477
+jtag newtap lpc4337 m0 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id 0x0ba01477
+dap create lpc4337.m0.dap -chain-position lpc4337.m0
+target create lpc4337.m0 cortex_m -dap lpc4337.m0.dap
 
-jtag newtap $_CHIPNAME m4 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_M4_JTAG_TAPID
-jtag newtap $_CHIPNAME m0 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_M0_JTAG_TAPID
+lpc4337.m4 configure -work-area-phys 0x10000000 -work-area-size 0x8000
 
-# https://elinux.org/OpenOCD_User_Guide
-# 21.3 OpenOCD specific Global Variables
-echo ""
-echo "Openocd is runninng on $ocd_HOSTOS" 
-echo ""
-if { $ocd_HOSTOS == "linux" } {
-   dap create $_CHIPNAME.m4.dap -chain-position $_CHIPNAME.m4
-   target create $_CHIPNAME.m4 cortex_m -dap $_CHIPNAME.m4.dap
-   dap create $_CHIPNAME.m0.dap -chain-position $_CHIPNAME.m0
-   target create $_CHIPNAME.m0 cortex_m -dap $_CHIPNAME.m0.dap
-} else {
-   target create $_CHIPNAME.m4 cortex_m -chain-position $_CHIPNAME.m4
-   target create $_CHIPNAME.m0 cortex_m -chain-position $_CHIPNAME.m0
-}
-
-set _WORKAREASIZE 0x8000
-$_CHIPNAME.m4 configure -work-area-phys 0x10000000 -work-area-size $_WORKAREASIZE
-
-set _FLASHNAME $_CHIPNAME.flash
-flash bank $_FLASHNAME lpc2000 0x1a000000 0x80000 0 0 $_CHIPNAME.m4 lpc4300 96000 calc_checksum
+flash bank lpc4337.flasha lpc2000 0x1a000000 0x80000 0 0 lpc4337.m4 lpc4300 96000 calc_checksum
+flash bank lpc4337.flashb lpc2000 0x1b000000 0x80000 0 0 lpc4337.m4 lpc4300 96000 calc_checksum
 
 reset_config none
-
 cortex_m reset_config vectreset
 
-targets $_CHIPNAME.m4
+targets lpc4337.m4
 
-$_CHIPNAME.m4 configure -event gdb-attach {
+lpc4337.m4 configure -event gdb-attach {
    echo "Reset Halt, due to gdb attached...!"
    reset halt
 }
 
-$_CHIPNAME.m4 configure -event gdb-detach {
+lpc4337.m4 configure -event gdb-detach {
    echo "Terminate openocd"
    shutdown 0
 }

--- a/scripts/openocd/lpc4337_old.cfg
+++ b/scripts/openocd/lpc4337_old.cfg
@@ -1,0 +1,166 @@
+###############################################################################
+#
+# Copyright 2014, Juan Cecconi (UTN-FRBA, Numetron)
+#
+# This file is part of CIAA Firmware.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+###############################################################################
+#OpenOCD configuration (target and interface) for CIAA-NXP
+
+######################################################################################################
+# Utilizar una interface tipo FTDI, todo lo que sigue está basado en ello
+######################################################################################################
+interface ftdi
+
+######################################################################################################
+# Agrego el Par VID-PID del FTDI, si hay más agregar a continuación...
+######################################################################################################
+ftdi_vid_pid 0x0403 0x6010
+
+######################################################################################################
+# Se utilizó el Channel A (ADBUS0 a ADBUS3) para conectar el JTAG mediante MPSSE
+######################################################################################################
+ftdi_channel 0
+
+######################################################################################################
+# ftdi_layout_init 'Valor' 'Dirección', Configura los GPIO (H-L), su valor y dirección en ese orden(1 = Salida, 0 = entrada)
+# los 16 bits se arman H-L como sigue 'ACBUS7-0+ADBUS7-0'
+#ADBUS0 = FT_CLCK = 1, salida de Clock
+#ADBUS1 = FT_TDI = 1, salida de datos del FT
+#ADBUS2 = FT_TDO = 0, entrada de datos al FT
+#ADBUS3 = FT_TMS = 1, salida de Test Mode Select, setear a 1
+#ADBUS4 = Pin 14 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ADBUS5 = Pin 12 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ADBUS6 = Pin 10 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ADBUS7 = Pin 8 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ACBUS0 = FT_TRST = 1, salida de TRST...va al buffer y luego no se usa, setear a 1
+#ACBUS1 = FT_RST = 1, salida de RST...va al buffer y luego no se usa, setear a 1
+#ACBUS2 = FT_OE = 1, salida de OE para manejar el Buffer del JTAG, setear a 1
+#ACBUS3 = Pin 6 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ACBUS4 = Pin 4 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ACBUS5 = Pin 2 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ACBUS6 = Pin 1 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+#ACBUS7 = Pin 3 - conector P9 = 1 salida para no dejar flotante e ingresar ruido al FT
+######################################################################################################
+ftdi_layout_init 0x0708 0xFFFB
+
+######################################################################################################
+# La creación de las señales que siguen no hacen falta porque se indicó en el Target cfg que no se
+# las tiene conectadas a ningún lado
+######################################################################################################
+
+######################################################################################################
+# Creo la señal llamada nTRST (Not TAP Reset) que es una tipo dato, y usa el bit 8 del GPIO (H-L), es
+# decir GPIOH0 (pin ACBUS0) por eso 0x100, y a la vez se activa conjuntamente con el OE que
+# está usado en el bit 10 del GPIO, es decir, en GPIOH2 (pin ACBUS2) por eso 0x400
+######################################################################################################
+ftdi_layout_signal nTRST -data 0x0100
+
+######################################################################################################
+# Creo la señal llamada nSRST (Not System Reset) que se activa cuando se hace un cmd 'reset'
+# Es tipo dato y usa el bit 9 del GPIO (H-L), es decir GPIOH1 (pin ACBUS1) por eso 0x200,
+# y a la vez se activa conjuntamente con el OE que  está usado en el bit 10 del GPIO, es decir,
+# en GPIOH2 (pin ACBUS2) por eso 0x400
+######################################################################################################
+ftdi_layout_signal nSRST -data 0x0200
+
+################################################################
+# Especifica en KHz la frecuencia del Clock en el JTAG (TCK)
+################################################################
+transport select jtag
+adapter_khz 2000
+
+################################################################
+# Defino nombre de CHIP
+################################################################
+set _CHIPNAME lpc4337
+
+################################################################
+# Defino los TAP del JTAG, para el core M4 y M0
+################################################################
+
+# M4 JTAG mode TAP
+set _M4_JTAG_TAPID 0x4ba00477
+
+# M0 TAP
+set _M0_JTAG_TAPID 0x0ba01477
+
+jtag newtap $_CHIPNAME m4 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_M4_JTAG_TAPID
+
+jtag newtap $_CHIPNAME m0 -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_M0_JTAG_TAPID
+
+################################################################
+# Creo los 2 targets lpc4337.m4 y lpc4337.m0
+################################################################
+target create $_CHIPNAME.m4 cortex_m -chain-position $_CHIPNAME.m4
+target create $_CHIPNAME.m0 cortex_m -chain-position $_CHIPNAME.m0
+
+################################################################
+# Defino un area de trabajo en la RAM para acelerar el proceso
+# de programación de la flash
+################################################################
+set _WORKAREASIZE 0x8000
+$_CHIPNAME.m4 configure -work-area-phys 0x10000000 -work-area-size $_WORKAREASIZE
+
+################################################################
+# Se define un banco de flash, grabable usando el driver lpc2000
+# que es compatible con el LPC4337
+# flash bank <name> lpc2000 <base> <size> 0 0 <target#> <variant> <clock> [calc checksum]
+################################################################
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME lpc2000 0x1a000000 0x80000 0 0 $_CHIPNAME.m4 lpc4300 96000 calc_checksum
+
+################################################################
+# TRST (TAP Reset) y SRST (System Reset) no están conectados más allá del Buffer
+# en el prototipo.
+# Por lo tanto se indica 'none'
+################################################################
+reset_config none
+#reset_config trst_only
+
+################################################################
+# on this CPU we should use VECTRESET to perform a soft reset and
+# manually reset the periphery
+# SRST or SYSRESETREQ disable the debug interface for the time of
+# the reset and will not fit our requirements for a consistent debug
+# session
+################################################################
+cortex_m reset_config vectreset
+
+targets $_CHIPNAME.m4
+
+$_CHIPNAME.m4 configure -event gdb-attach {
+   echo "Reset Halt, due to gdb attached...!"
+   reset halt
+}
+
+$_CHIPNAME.m4 configure -event gdb-detach {
+   echo "Terminate openocd"
+   shutdown 0
+}


### PR DESCRIPTION
This fix the "dap" command format for new openocd maintaining the old openocd version
working using tcl command check

Signed-off-by: Martin Ribelotta <martinribelotta@gmail.com>