### PR TITLE
bugfix: pass configured params to uart callbacks

### DIFF
--- a/libs/sapi/sapi_v0.5.2/soc/peripherals/src/sapi_uart.c
+++ b/libs/sapi/sapi_v0.5.2/soc/peripherals/src/sapi_uart.c
@@ -113,13 +113,13 @@ static void uartProcessIRQ( uartMap_t uart )
    if(status & UART_LSR_RDR) { // uartRxReady
       // Execute callback
       if( ( uart == UART_GPIO ) && (rxIsrCallbackUART0 != 0) )
-         (*rxIsrCallbackUART0)(0);
+         (*rxIsrCallbackUART0)(rxIsrCallbackUART0Params);
 
       if( ( uart == UART_USB )  && (rxIsrCallbackUART2 != 0) )
-         (*rxIsrCallbackUART2)(0);
+         (*rxIsrCallbackUART2)(rxIsrCallbackUART2Params);
 
       if( ( uart == UART_232 )  && (rxIsrCallbackUART3 != 0) )
-         (*rxIsrCallbackUART3)(0);
+         (*rxIsrCallbackUART3)(rxIsrCallbackUART3Params);
    }
 
    // Tx Interrupt
@@ -128,13 +128,13 @@ static void uartProcessIRQ( uartMap_t uart )
 
       // Execute callback
       if( ( uart == UART_GPIO ) && (txIsrCallbackUART0 != 0) )
-         (*txIsrCallbackUART0)(0);
+         (*txIsrCallbackUART0)(txIsrCallbackUART0Params);
 
       if( ( uart == UART_USB )  && (txIsrCallbackUART2 != 0) )
-         (*txIsrCallbackUART2)(0);
+         (*txIsrCallbackUART2)(txIsrCallbackUART2Params);
 
       if( ( uart == UART_232 )  && (txIsrCallbackUART3 != 0) )
-         (*txIsrCallbackUART3)(0);
+         (*txIsrCallbackUART3)(txIsrCallbackUART3Params);
    }
 }
 #endif /* SAPI_USE_INTERRUPTS */


### PR DESCRIPTION
`callbackParam` argument of `uartCallbackSet()` was being ignored in
`uartProcessIRQ()`.