### PR TITLE
Add assembly code that requires preprocessing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,9 +64,14 @@ INOSRC+=$(foreach m, $(MODULES), $(wildcard $(m)/src/*.ino))
 ASRC+=$(wildcard $(PROGRAM_PATH_AND_NAME)/src/*.s)
 ASRC+=$(foreach m, $(MODULES), $(wildcard $(m)/src/*.s))
 
+ASSRC+=$(wildcard $(PROGRAM_PATH_AND_NAME)/src/*.S)
+ASSRC+=$(foreach m, $(MODULES), $(wildcard $(m)/src/*.S))
+
 OUT=$(PROGRAM_PATH_AND_NAME)/out
 # Arduino
 OBJECTS=$(INOSRC:%.ino=$(OUT)/%.o) $(CXXSRC:%.cpp=$(OUT)/%.o) $(SRC:%.c=$(OUT)/%.o) $(ASRC:%.s=$(OUT)/%.o)
+
+OBJECTS+=$(ASSRC:%.S=$(OUT)/%.o)
 
 DEPS=$(OBJECTS:%.o=%.d)
 
@@ -175,6 +180,11 @@ $(OUT)/%.o: %.ino
 
 $(OUT)/%.o: %.s
 	@echo AS $(notdir $<)
+	@mkdir -p $(dir $@)
+	$(Q)$(CC) -MMD $(CFLAGS) -c -o $@ $<
+
+$(OUT)/%.o: %.S
+	@echo AS $<
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) -MMD $(CFLAGS) -c -o $@ $<
 

--- a/examples/asm/asm_c_directives/config.mk
+++ b/examples/asm/asm_c_directives/config.mk
@@ -1,0 +1,6 @@
+# Compile options
+VERBOSE=n
+OPT=g
+USE_NANO=y
+SEMIHOST=n
+USE_FPU=y

--- a/examples/asm/asm_c_directives/inc/main.h
+++ b/examples/asm/asm_c_directives/inc/main.h
@@ -1,0 +1,75 @@
+/* Copyright 2018, Facundo Larosa - Danilo Zecchin
+ * All rights reserved.
+ *
+ * This file is part of arquitecturaDeMicroprocesadores.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _MAIN_H_
+#define _MAIN_H_
+
+/** \addtogroup blink Bare-metal blink example
+ ** @{ */
+
+/*==================[inclusions]=============================================*/
+
+/*==================[cplusplus]==============================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================[macros]=================================================*/
+
+/** delay in milliseconds */
+#define DELAY_MS 500
+
+/** led number to toggle */
+#define LED 0
+
+/*==================[typedef]================================================*/
+
+/*==================[external data declaration]==============================*/
+
+/*==================[external functions declaration]=========================*/
+
+/** @brief main function
+ * @return main function should never return
+ */
+int main(void);
+
+/*==================[cplusplus]==============================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} doxygen end group definition */
+/*==================[end of file]============================================*/
+#endif /* #ifndef _MAIN_H_ */

--- a/examples/asm/asm_c_directives/inc/suma.h
+++ b/examples/asm/asm_c_directives/inc/suma.h
@@ -1,0 +1,70 @@
+/* Copyright 2018, Facundo Larosa - Danilo Zecchin
+ * All rights reserved.
+ *
+ * This file is part of arquitecturaDeMicroprocesadores.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef _SUMA_H_
+#define _SUMA_H_
+
+/*==================[inclusions]=============================================*/
+#include <stdint.h>
+
+/*==================[cplusplus]==============================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*==================[macros]=================================================*/
+
+/*==================[typedef]================================================*/
+
+/*==================[external data declaration]==============================*/
+
+/*==================[external functions declaration]=========================*/
+
+/**
+ * Funcion que suma dos enteros de 32 bits y devuelve el resultado
+ * @param firstOperand primer sumando
+ * @param secondOperand segundo sumando
+ * @return suma
+ */
+extern uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
+extern uint32_t CSum(uint32_t firstOperand, uint32_t secondOperand);
+/*==================[cplusplus]==============================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} doxygen end group definition */
+/*==================[end of file]============================================*/
+#endif /* #ifndef _MAIN_H_ */

--- a/examples/asm/asm_c_directives/src/main.c
+++ b/examples/asm/asm_c_directives/src/main.c
@@ -1,0 +1,92 @@
+/* Copyright 2018, Facundo Larosa - Danilo Zecchin
+ * All rights reserved.
+ *
+ * This file is part of arquitecturaDeMicroprocesadores.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/** @brief This is a simple blink example.
+ */
+
+/** \addtogroup blink Bare-metal blink example
+ ** @{ */
+
+/*==================[inclusions]=============================================*/
+
+#include "main.h"
+#include "board.h"
+#include "suma.h"
+
+/*==================[macros and definitions]=================================*/
+
+/*==================[internal data declaration]==============================*/
+
+/*==================[internal functions declaration]=========================*/
+
+/** @brief hardware initialization function
+ *	@return none
+ */
+static void initHardware(void);
+
+/*==================[internal data definition]===============================*/
+
+/*==================[external data definition]===============================*/
+
+/*==================[internal functions definition]==========================*/
+
+static void initHardware(void)
+{
+	Board_Init();
+	SystemCoreClockUpdate();
+	//SysTick_Config(SystemCoreClock / 1000);
+}
+
+/*==================[external functions definition]==========================*/
+
+int main(void)
+{
+	volatile  uint32_t aValue = 20,
+			 otherValue = 30,
+			 sumResult_Asm,sumResult_C;
+
+	initHardware();
+
+	sumResult_C= CSum(aValue,otherValue);
+
+	sumResult_Asm = asmSum(aValue, otherValue);
+
+	while (1)
+	{
+		__WFI(); //wfi
+	}
+}
+
+/** @} doxygen end group definition */
+
+/*==================[end of file]============================================*/

--- a/examples/asm/asm_c_directives/src/suma.S
+++ b/examples/asm/asm_c_directives/src/suma.S
@@ -1,0 +1,83 @@
+/** Ejemplo de archivo de assembler */
+
+/* Copyright 2018, Facundo Larosa - Danilo Zecchin
+ * All rights reserved.
+ *
+ * This file is part of arquitecturaDeMicroprocesadores.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+	/**
+	 * Directiva al ensablador que permite indicar que se encarga de buscar
+	 * la instruccion mas apropiada entre ARM y thumb2
+	 */
+	.syntax unified
+
+	/**
+	 * .text permite indicar una seccion de codigo.
+	 */
+	.text
+
+	/**
+	 * .global permite definir un simbolo exportable,
+	 * es decir que podemos verlo desde otros modulos (equivalente a extern).
+     * Definimos la rutina como global para que sea visible desde otros modulos.
+     */
+	.global asmSum
+
+
+#define op1 r0
+#define op2 r1
+
+	/**
+	 * Indicamos que la siguiente subrutina debe ser ensamblada en modo thumb,
+	 * entonces en las direcciones en el ultimo bit tendran el 1 para que se reconozcan como en modo thumb.
+	 * Siempre hay que ponerla antes de la primer instruccion.
+	 */
+	.thumb_func
+
+
+/**
+ *	prototipo de la funcion en C
+ *
+ *	uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
+ *
+ *	En r0 se cargara firstOperand y en r1 se carga secondOperand. Luego el valor devuelto estara en r0 (si son 32 bits).
+ *	Si el resultado que retorna es en 64 bits, usa r0 y r1.
+*/
+
+asmSum:
+    push {lr}  /* guardamos la direccion de retorno en la pila */
+	add op1, op2 /* r0 = r0 + r1 */
+	pop {pc}   /* retorno */
+
+	/* otras alternativas para el retorno */
+	/* 1. mov pc,lr
+	/  2. bx lr */
+	/* pop {pc} */

--- a/examples/asm/asm_c_directives/src/suma_c.c
+++ b/examples/asm/asm_c_directives/src/suma_c.c
@@ -1,0 +1,13 @@
+/*
+ * suma.c
+ *
+ *  Created on: 15 sep. 2018
+ *      Author: fsl
+ */
+#include <suma.h>
+uint32_t CSum(uint32_t firstOperand, uint32_t secondOperand)
+{
+	return firstOperand+secondOperand;
+}
+
+

--- a/scripts/program/templates/asm_c_directives.sh
+++ b/scripts/program/templates/asm_c_directives.sh
@@ -44,6 +44,7 @@ $FILE_HEADER
 
 #include "${PROGRAM_NAME}.h"
 #include "asm_module.h"
+#include "c_function.h"
 #include "sapi.h"
 
 /*=====[Definition macros of private constants]==============================*/
@@ -56,28 +57,38 @@ $FILE_HEADER
 
 /*=====[Main function, program entry point after power on or reset]==========*/
 
-int main( void )
-{
-/*=====[Definitions of private local variables]=============================*/
-	volatile  uint32_t aValue = 20,
-			 otherValue = 30,
-			 sumResult_Asm,sumResult_C;
-			 
-// ----- Setup -----------------------------------
-   	boardInit();
-	
-	sumResult_Asm = asmSum(aValue, otherValue);
+int main(void) {
 
+	/*=====[Definitions of private local variables]=============================*/
+	volatile uint32_t A = 10, B = 20, C = 30, D = 40, sumResult_Asm,
+			sumResult_C;
+
+// ----- Setup -----------------------------------
+	boardInit();
+
+	sumResult_Asm = asmFunction(A, B, C, D);
+	sumResult_C = c_function(A, B, C, D);
 // ----- Repeat for ever -------------------------
-   while( true ) {
+	while ( true) {
 		__WFI(); //wfi
 	}
 
-   // YOU NEVER REACH HERE, because this program runs directly or on a
-   // microcontroller and is not called by any Operating System, as in the 
-   // case of a PC program.
-   return 0;
+	// YOU NEVER REACH HERE, because this program runs directly or on a
+	// microcontroller and is not called by any Operating System, as in the
+	// case of a PC program.
+	return 0;
 }
+EOF
+
+cat <<EOF > ${PB}/src/c_function.c
+$FILE_HEADER
+
+#include "c_function.h"
+
+uint32_t c_function(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3){
+	return (arg0+arg1+arg2+arg3);
+}
+
 EOF
 
 cat <<EOF > ${PB}/src/asm_module.S
@@ -99,7 +110,7 @@ $FILE_HEADER
  * es decir que podemos verlo desde otros modulos (equivalente a extern).
  * Definimos la rutina como global para que sea visible desde otros modulos.
  */
-.global asmSum
+.global asmFunction
 
 /**
  * Indicamos que la siguiente subrutina debe ser ensamblada en modo thumb,
@@ -113,20 +124,21 @@ $FILE_HEADER
 
 #define op1 r0
 #define op2 r1
+#define op3 r2
+#define op4 r3
 
 /*=====[Implementations of public assembly functions]=================================*/
 
 /**
  *	prototipo de la funcion en C
  *
- *	uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
- *
- *	En r0 se cargara firstOperand y en r1 se carga secondOperand. Luego el valor devuelto estara en r0 (si son 32 bits).
- *	Si el resultado que retorna es en 64 bits, usa r0 y r1.
+ *	uint32_t asmFunction(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3);
 */
-asmSum:
+asmFunction:
     push {lr}  /* guardamos la direccion de retorno en la pila */
 	add op1, op2 /* r0 = r0 + r1 */
+	add op1, op3 /* r0 = r0 + r2 */
+	add op1, op4 /* r0 = r0 + r3 */
 	pop {pc}   /* retorno */
 
 	/* otras alternativas para el retorno */
@@ -175,18 +187,39 @@ extern "C" {
 #endif /* __${PROGRAM_NAME_UPPER}_H__ */
 EOF
 
+cat <<EOF > ${PB}/inc/c_function.h
+$FILE_HEADER
+
+#ifndef __${PROGRAM_NAME_UPPER}_C_FUNCTION_H__
+#define __${PROGRAM_NAME_UPPER}_C_FUNCTION_H__
+
+#include "${PROGRAM_NAME}.h"
+
+/**
+ * c_function do the same of ASM function for compare purpose
+ * 
+ * @param arg0
+ * @param arg1
+ * @param arg2
+ * @param arg3
+ * @return
+ */
+uint32_t c_function(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3);
+
+#endif /* __${PROGRAM_NAME_UPPER}_C_FUNCTION_H__ */
+EOF
+
 cat <<EOF > ${PB}/inc/asm_module.h
 $FILE_HEADER
 
 /*=====[Avoid multiple inclusion - begin]====================================*/
 
-#ifndef __ASM_MODULE_H__
-#define __ASM_MODULE_H__
+#ifndef __${PROGRAM_NAME_UPPER}_ASM_MODULE_H__
+#define __${PROGRAM_NAME_UPPER}_ASM_MODULE_H__
 
 /*=====[Inclusions of public function dependencies]==========================*/
 
-#include <stdint.h>
-#include <stddef.h>
+#include "${PROGRAM_NAME}.h"
 
 /*=====[C++ - begin]=========================================================*/
 
@@ -209,12 +242,27 @@ extern "C" {
 /*=====[external functions declaration]======================================*/
 
 /**
- * Funcion que suma dos enteros de 32 bits y devuelve el resultado
- * @param firstOperand primer sumando
- * @param secondOperand segundo sumando
- * @return suma
+ * @brief C prototype function link with asm_module
+ *
+ * Automatically when you call and return from function, MCU utilizes these register:
+ * 
+ * |   C	| CORE    |
+ * | ----- 	| ------- |
+ * |  r0	|  arg0   |
+ * |  r1 	|  arg1   |
+ * |  r2 	|  arg2   |
+ * |  r3 	|  arg3   |
+ * | ----- 	| ------- |
+ * |  r0 	| returnL |
+ * |  r1 	| returnH |
+ *
+ * @param arg0
+ * @param arg1
+ * @param arg2
+ * @param arg3
+ * @return implicit in r0 when return its 32bits, and r1-r0 when is 64bits
  */
-extern uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
+extern uint32_t asmFunction(uint32_t arg0, uint32_t arg1, uint32_t arg2, uint32_t arg3);
 
 /*=====[C++ - end]===========================================================*/
 
@@ -224,5 +272,5 @@ extern uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
 
 /*=====[Avoid multiple inclusion - end]======================================*/
 
-#endif /* __ASM_MODULE__ */
+#endif /* __${PROGRAM_NAME_UPPER}_ASM_MODULE__ */
 EOF

--- a/scripts/program/templates/asm_c_directives.sh
+++ b/scripts/program/templates/asm_c_directives.sh
@@ -1,0 +1,228 @@
+#!/bin/sh
+
+# BSD 3-Clause License
+# Copyright (c) 2019, Eric Pernia and Martin Ribelotta
+# All rights reserved.
+
+mkdir -p ${PB}/src
+mkdir -p ${PB}/inc
+
+PROGRAM_NAME_UPPER=$(echo $PROGRAM_NAME | tr '[:lower:]' '[:upper:]')
+
+#$LICENSE_PATH
+
+#$PROGRAMS_FOLDER
+#$AUTHOR_FULL_NAME
+#$AUTHOR_EMAIL
+#$LICENSE
+
+#$PROGRAM_NAME
+#$PROGRAM_VERSION
+#$PROGRAM_TEMPLATE
+
+cat <<EOF > ${PB}/config.mk
+# Compile options
+VERBOSE=n
+OPT=g
+USE_NANO=y
+SEMIHOST=n
+USE_FPU=y
+EOF
+
+if [ -f "$LICENSE_PATH/license_file_header.sh" ]
+then
+	. "$LICENSE_PATH/license_file_header.sh"
+else
+	echo "Error, license_file_header.sh not found."
+	FILE_HEADER=""
+fi
+
+cat <<EOF > ${PB}/src/${PROGRAM_NAME}.c
+$FILE_HEADER
+
+/*=====[Inclusions of function dependencies]=================================*/
+
+#include "${PROGRAM_NAME}.h"
+#include "asm_module.h"
+#include "sapi.h"
+
+/*=====[Definition macros of private constants]==============================*/
+
+/*=====[Definitions of extern global variables]==============================*/
+
+/*=====[Definitions of public global variables]==============================*/
+
+/*=====[Definitions of private global variables]=============================*/
+
+/*=====[Main function, program entry point after power on or reset]==========*/
+
+int main( void )
+{
+/*=====[Definitions of private local variables]=============================*/
+	volatile  uint32_t aValue = 20,
+			 otherValue = 30,
+			 sumResult_Asm,sumResult_C;
+			 
+// ----- Setup -----------------------------------
+   	boardInit();
+	
+	sumResult_Asm = asmSum(aValue, otherValue);
+
+// ----- Repeat for ever -------------------------
+   while( true ) {
+		__WFI(); //wfi
+	}
+
+   // YOU NEVER REACH HERE, because this program runs directly or on a
+   // microcontroller and is not called by any Operating System, as in the 
+   // case of a PC program.
+   return 0;
+}
+EOF
+
+cat <<EOF > ${PB}/src/asm_module.S
+$FILE_HEADER
+
+/**
+ * Directiva al ensablador que permite indicar que se encarga de buscar
+ * la instruccion mas apropiada entre ARM y thumb2
+ */
+.syntax unified
+
+/**
+ * .text permite indicar una seccion de codigo.
+ */
+.text
+
+/**
+ * .global permite definir un simbolo exportable,
+ * es decir que podemos verlo desde otros modulos (equivalente a extern).
+ * Definimos la rutina como global para que sea visible desde otros modulos.
+ */
+.global asmSum
+
+/**
+ * Indicamos que la siguiente subrutina debe ser ensamblada en modo thumb,
+ * entonces en las direcciones en el ultimo bit tendran el 1 para que se reconozcan como en modo thumb.
+ * Siempre hay que ponerla antes de la primer instruccion.
+ */
+.thumb_func
+
+
+/*=====[Definition macros of public constants]===============================*/
+
+#define op1 r0
+#define op2 r1
+
+/*=====[Implementations of public assembly functions]=================================*/
+
+/**
+ *	prototipo de la funcion en C
+ *
+ *	uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
+ *
+ *	En r0 se cargara firstOperand y en r1 se carga secondOperand. Luego el valor devuelto estara en r0 (si son 32 bits).
+ *	Si el resultado que retorna es en 64 bits, usa r0 y r1.
+*/
+asmSum:
+    push {lr}  /* guardamos la direccion de retorno en la pila */
+	add op1, op2 /* r0 = r0 + r1 */
+	pop {pc}   /* retorno */
+
+	/* otras alternativas para el retorno */
+	/* 1. mov pc,lr
+	/  2. bx lr */
+	/* pop {pc} */
+EOF
+
+cat <<EOF > ${PB}/inc/${PROGRAM_NAME}.h
+$FILE_HEADER
+
+/*=====[Avoid multiple inclusion - begin]====================================*/
+
+#ifndef __${PROGRAM_NAME_UPPER}_H__
+#define __${PROGRAM_NAME_UPPER}_H__
+
+/*=====[Inclusions of public function dependencies]==========================*/
+
+#include <stdint.h>
+#include <stddef.h>
+
+/*=====[C++ - begin]=========================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=====[Definition macros of public constants]===============================*/
+
+/*=====[Public function-like macros]=========================================*/
+
+/*=====[Definitions of public data types]====================================*/
+
+/*=====[Prototypes (declarations) of public functions]=======================*/
+
+/*=====[Prototypes (declarations) of public interrupt functions]=============*/
+
+/*=====[C++ - end]===========================================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/*=====[Avoid multiple inclusion - end]======================================*/
+
+#endif /* __${PROGRAM_NAME_UPPER}_H__ */
+EOF
+
+cat <<EOF > ${PB}/inc/asm_module.h
+$FILE_HEADER
+
+/*=====[Avoid multiple inclusion - begin]====================================*/
+
+#ifndef __ASM_MODULE_H__
+#define __ASM_MODULE_H__
+
+/*=====[Inclusions of public function dependencies]==========================*/
+
+#include <stdint.h>
+#include <stddef.h>
+
+/*=====[C++ - begin]=========================================================*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*=====[Definition macros of public constants]===============================*/
+
+/*=====[Public function-like macros]=========================================*/
+
+/*=====[Definitions of public data types]====================================*/
+
+/*=====[Prototypes (declarations) of public functions]=======================*/
+
+/*=====[Prototypes (declarations) of public interrupt functions]=============*/
+
+/*=====[External data declaration]===========================================*/
+
+/*=====[external functions declaration]======================================*/
+
+/**
+ * Funcion que suma dos enteros de 32 bits y devuelve el resultado
+ * @param firstOperand primer sumando
+ * @param secondOperand segundo sumando
+ * @return suma
+ */
+extern uint32_t asmSum(uint32_t firstOperand, uint32_t secondOperand);
+
+/*=====[C++ - end]===========================================================*/
+
+#ifdef __cplusplus
+}
+#endif
+
+/*=====[Avoid multiple inclusion - end]======================================*/
+
+#endif /* __ASM_MODULE__ */
+EOF


### PR DESCRIPTION
@epernia este PR agrega 
- Ejemplo visto en Arquitecturas de Microprocesadores de usando código _assembly_ y directivas de preprocesamiento de C
- Template para crear un nuevo programa usando código _assembly_ y directivas de preprocesamiento de C
- Modificaciones de `Makefile` para compilar arquivos con extensión `.S` (mayúsculas)

# Referencia
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0773g/chr1383143887630.html