### PR TITLE
Fix initialization routine

### DIFF
--- a/libs/sapi/sapi_v0.6.2/external_peripherals/display/drivers/LCD/HD44780/GPIOs/display_lcd_hd44780_gpios.c
+++ b/libs/sapi/sapi_v0.6.2/external_peripherals/display/drivers/LCD/HD44780/GPIOs/display_lcd_hd44780_gpios.c
@@ -251,14 +251,6 @@ void lcdInit( uint16_t lineWidth, uint16_t amountOfLines,
    lcdPinSet( LCD_HD44780_RS, OFF );     // RS = 0
    lcdPinSet( LCD_HD44780_EN, OFF );     // EN = 0
 
-        lcdPinSet( LCD_HD44780_RST, ON );     // RST = 1
-        lcdDelay_us(100);                     // Wait
-        
-        lcdPinSet( LCD_HD44780_RST, OFF );    // RST = 0
-        lcdDelay_ms(10);
-        lcdPinSet( LCD_HD44780_RST, ON );     // RST = 1
-        lcdDelay_ms(50);
-
         //lcdCommand( 0x20 );                   // Command 0x20 for 4-bit mode
         lcdCommand( 0x30 );                   // Command 0x20 for 4-bit mode
         lcdCommandDelay();                    // Wait


### PR DESCRIPTION
The example for module hd44780 with I2C extender PCF8574 doesn't work the builder crashes. There is a problem in the drivers, specifically in the LCD initialization routine. I fixed it deleting these lines, and it all worked perfectly. Maybe they are not necessary.