### PR TITLE
Support .sx & .S files compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,11 @@ $(OUT)/%.o: %.s
 	@mkdir -p $(dir $@)
 	$(Q)$(CC) -MMD $(CFLAGS) -c -o $@ $<
 
+$(OUT)/%.o: %.sx
+	@echo AS $(notdir $<)
+	@mkdir -p $(dir $@)
+	$(Q)$(CC) -MMD $(CFLAGS) -c -o $@ $<
+
 $(OUT)/%.o: %.S
 	@echo AS $<
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,9 @@ ASRC+=$(foreach m, $(MODULES), $(wildcard $(m)/src/*.s))
 ASSRC+=$(wildcard $(PROGRAM_PATH_AND_NAME)/src/*.sx)
 ASSRC+=$(foreach m, $(MODULES), $(wildcard $(m)/src/*.sx))
 
+ASSSRC+=$(wildcard $(PROGRAM_PATH_AND_NAME)/src/*.S)
+ASSSRC+=$(foreach m, $(MODULES), $(wildcard $(m)/src/*.S))
+
 OUT=$(PROGRAM_PATH_AND_NAME)/out
 
 OBJECTS=$(INOSRC:%.ino=$(OUT)/%.o)
@@ -76,6 +79,7 @@ OBJECTS+=$(CXXSRC:%.cpp=$(OUT)/%.o)
 OBJECTS+=$(SRC:%.c=$(OUT)/%.o)
 OBJECTS+=$(ASRC:%.s=$(OUT)/%.o)
 OBJECTS+=$(ASSRC:%.sx=$(OUT)/%.o)
+OBJECTS+=$(ASSSRC:%.S=$(OUT)/%.o)
 
 $(info $(OBJECTS))
 


### PR DESCRIPTION
There's an issue compiling `/examples/asm/asm_c_directives` due to the Makefile not considering `.sx` files. 
This fix adds what's necessary to make it compile.